### PR TITLE
End to end tracing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build
 dist
 cinderclient/versioninfo
 python_cinderclient.egg-info
+.ropeproject

--- a/cinderclient/client.py
+++ b/cinderclient/client.py
@@ -796,12 +796,13 @@ def Client(version, *args, **kwargs):
     # NOTE(jethro): options.profile demonstrate the --profile, here set to
     # be true by default
     options.profile = "42"
-    profile = osprofiler_profiler and options.profile
+    profile = options.profile
     if profile and is_sampled(SAMPLING_RATE):
         print("sampled request")
         osprofiler_profiler.init(options.profile)
     return client_class(api_version=api_version,
                         *args, **kwargs)
+    """
     try:
         trace_id = osprofiler_profiler.get().get_base_id()
         print("Trace ID: %s" % trace_id)
@@ -814,3 +815,4 @@ def Client(version, *args, **kwargs):
         subprocess.call(["bash", "-c", cmd])
     except:
         pass
+    """

--- a/cinderclient/client.py
+++ b/cinderclient/client.py
@@ -795,11 +795,10 @@ def Client(version, *args, **kwargs):
     api_version, client_class = _get_client_class_and_version(version)
     # NOTE(jethro): options.profile demonstrate the --profile, here set to
     # be true by default
-    options.profile = "42"
-    profile = options.profile
+    profile = "42"  #options.profile
     if profile and is_sampled(SAMPLING_RATE):
         print("sampled request")
-        osprofiler_profiler.init(options.profile)
+        osprofiler_profiler.init(profile)
     return client_class(api_version=api_version,
                         *args, **kwargs)
     """

--- a/cinderclient/client.py
+++ b/cinderclient/client.py
@@ -59,24 +59,6 @@ try:
 except ImportError:
     import simplejson as json
 
-# -------------------------------------------------
-# NOTE(jethro): below are a little things I stuffed
-# -------------------------------------------------
-import random
-import subprocess
-
-
-def is_sampled(rate):
-    MAX_RANGE = 100
-    if random.randint(0, 100) < MAX_RANGE * rate:
-        return True
-    return False
-
-SAMPLING_RATE = 0.5
-
-osprofiler_profiler = importutils.try_import("osprofiler.profiler")
-
-
 _VALID_VERSIONS = ['v1', 'v2', 'v3']
 V3_SERVICE_TYPE = 'volumev3'
 V2_SERVICE_TYPE = 'volumev2'
@@ -96,7 +78,7 @@ def get_server_version(url):
 
     :param url: url of the cinder endpoint
     :returns: APIVersion object for min and max version supported by
-    the server
+              the server
     """
 
     logger = logging.getLogger(__name__)
@@ -111,7 +93,7 @@ def get_server_version(url):
                         api_versions.APIVersion(version['version']))
     except exceptions.ClientException as e:
         logger.warning(_LW("Error in server version query:%s\n"
-                           "Returning APIVersion 2.0") % six.text_type(e.message))
+                 "Returning APIVersion 2.0") % six.text_type(e.message))
         return api_versions.APIVersion("2.0"), api_versions.APIVersion("2.0")
 
 
@@ -124,7 +106,7 @@ def get_volume_api_from_url(url):
             return version[1:]
 
     msg = (_("Invalid url: '%(url)s'. It must include one of: %(version)s.")
-           % {'url': url, 'version': ', '.join(_VALID_VERSIONS)})
+        % {'url': url, 'version': ', '.join(_VALID_VERSIONS)})
     raise exceptions.UnsupportedVersion(msg)
 
 
@@ -321,7 +303,7 @@ class HTTPClient(object):
         if 'data' in kwargs:
             data = strutils.mask_password(kwargs['data'])
             string_parts.append(" -d '%s'" % (data))
-            self._logger.debug("\nREQ: %s\n" % "".join(string_parts))
+        self._logger.debug("\nREQ: %s\n" % "".join(string_parts))
 
     def http_log_resp(self, resp):
         if not self.http_log_debug:
@@ -347,17 +329,17 @@ class HTTPClient(object):
         if 'body' in kwargs:
             kwargs['headers']['Content-Type'] = 'application/json'
             kwargs['data'] = json.dumps(kwargs.pop('body'))
-            api_versions.update_headers(kwargs["headers"], self.api_version)
+        api_versions.update_headers(kwargs["headers"], self.api_version)
 
         if self.timeout:
             kwargs.setdefault('timeout', self.timeout)
-            self.http_log_req((url, method,), kwargs)
-            resp = requests.request(
-                method,
-                url,
-                verify=self.verify_cert,
-                **kwargs)
-            self.http_log_resp(resp)
+        self.http_log_req((url, method,), kwargs)
+        resp = requests.request(
+            method,
+            url,
+            verify=self.verify_cert,
+            **kwargs)
+        self.http_log_resp(resp)
 
         body = None
         if resp.text:
@@ -379,20 +361,20 @@ class HTTPClient(object):
             attempts += 1
             if not self.management_url or not self.auth_token:
                 self.authenticate()
-                kwargs.setdefault('headers', {})['X-Auth-Token'] = self.auth_token
-                if self.projectid:
-                    kwargs['headers']['X-Auth-Project-Id'] = self.projectid
-                    try:
-                        if not url.startswith(self.management_url):
-                            url = self.management_url + url
-                            resp, body = self.request(url, method, **kwargs)
-                            return resp, body
-                    except exceptions.BadRequest as e:
-                        if attempts > self.retries:
-                            raise
-                    except exceptions.Unauthorized:
-                        if auth_attempts > 0:
-                            raise
+            kwargs.setdefault('headers', {})['X-Auth-Token'] = self.auth_token
+            if self.projectid:
+                kwargs['headers']['X-Auth-Project-Id'] = self.projectid
+            try:
+                if not url.startswith(self.management_url):
+                    url = self.management_url + url
+                resp, body = self.request(url, method, **kwargs)
+                return resp, body
+            except exceptions.BadRequest as e:
+                if attempts > self.retries:
+                    raise
+            except exceptions.Unauthorized:
+                if auth_attempts > 0:
+                    raise
                 self._logger.debug("Unauthorized, reauthenticating.")
                 self.management_url = self.auth_token = None
                 # First reauth. Discount this attempt.
@@ -526,11 +508,11 @@ class HTTPClient(object):
         port = magic_tuple.port
         if port is None:
             port = 80
-            path_parts = path.split('/')
-            for part in path_parts:
-                if len(part) > 0 and part[0] == 'v':
-                    self.version = part
-                    break
+        path_parts = path.split('/')
+        for part in path_parts:
+            if len(part) > 0 and part[0] == 'v':
+                self.version = part
+                break
 
         # TODO(sandy): Assume admin endpoint is 35357 for now.
         # Ideally this is going to have to be provided by the service catalog.
@@ -554,21 +536,21 @@ class HTTPClient(object):
                     self.set_management_url(self.bypass_url)
                 else:
                     self._fetch_endpoints_from_auth(admin_url)
-                    # Since keystone no longer returns the user token
-                    # with the endpoints any more, we need to replace
-                    # our service account token with the user token.
-                    self.auth_token = self.proxy_token
-            else:
-                try:
-                    while auth_url:
-                        auth_url = self._v1_auth(auth_url)
-                        # In some configurations cinder makes redirection to
-                        # v2.0 keystone endpoint. Also, new location does not contain
-                        # real endpoint, only hostname and port.
-                except exceptions.AuthorizationFailure:
-                    if auth_url.find('v2.0') < 0:
-                        auth_url = auth_url + '/v2.0'
-                        self._v2_or_v3_auth(auth_url)
+                # Since keystone no longer returns the user token
+                # with the endpoints any more, we need to replace
+                # our service account token with the user token.
+                self.auth_token = self.proxy_token
+        else:
+            try:
+                while auth_url:
+                    auth_url = self._v1_auth(auth_url)
+            # In some configurations cinder makes redirection to
+            # v2.0 keystone endpoint. Also, new location does not contain
+            # real endpoint, only hostname and port.
+            except exceptions.AuthorizationFailure:
+                if auth_url.find('v2.0') < 0:
+                    auth_url = auth_url + '/v2.0'
+                self._v2_or_v3_auth(auth_url)
 
         if self.bypass_url:
             self.set_management_url(self.bypass_url)
@@ -630,7 +612,7 @@ class HTTPClient(object):
                 body['auth']['tenantName'] = self.projectid
             elif self.tenant_id:
                 body['auth']['tenantId'] = self.tenant_id
-                self._authenticate(url, body)
+        self._authenticate(url, body)
 
     def _authenticate(self, url, body):
         """Authenticate and extract the service catalog."""
@@ -638,12 +620,12 @@ class HTTPClient(object):
             token_url = url + "/auth/tokens"
         else:
             token_url = url + "/tokens"
-            # Make sure we follow redirects when trying to reach Keystone
-            resp, body = self.request(
-                token_url,
-                "POST",
-                body=body,
-                allow_redirects=True)
+        # Make sure we follow redirects when trying to reach Keystone
+        resp, body = self.request(
+            token_url,
+            "POST",
+            body=body,
+            allow_redirects=True)
 
         return self._extract_service_catalog(url, resp, body)
 
@@ -708,9 +690,9 @@ def _get_client_class_and_version(version):
         version = api_versions.get_api_version(version)
     else:
         api_versions.check_major_version(version)
-        if version.is_latest():
-            raise exceptions.UnsupportedVersion(
-                _("The version should be explicit, not latest."))
+    if version.is_latest():
+        raise exceptions.UnsupportedVersion(
+            _("The version should be explicit, not latest."))
     return version, importutils.import_class(
         "cinderclient.v%s.client.Client" % version.ver_major)
 
@@ -734,8 +716,8 @@ def get_client_class(version):
 def discover_extensions(version):
     extensions = []
     for name, module in itertools.chain(
-        _discover_via_python_path(),
-        _discover_via_contrib_path(version)):
+            _discover_via_python_path(),
+            _discover_via_contrib_path(version)):
 
         extension = cinderclient.extension.Extension(name, module)
         extensions.append(extension)
@@ -774,14 +756,14 @@ def Client(version, *args, **kwargs):
     """Initialize client object based on given version.
 
     HOW-TO:
-        The simplest way to create a client instance is initialization with your
-        credentials::
+    The simplest way to create a client instance is initialization with your
+    credentials::
 
     .. code-block:: python
 
         >>> from cinderclient import client
         >>> cinder = client.Client(VERSION, USERNAME, PASSWORD,
-                                   ...                      PROJECT_NAME, AUTH_URL)
+        ...                      PROJECT_NAME, AUTH_URL)
 
     Here ``VERSION`` can be a string or
     ``cinderclient.api_versions.APIVersion`` obj. If you prefer string value,
@@ -793,15 +775,7 @@ def Client(version, *args, **kwargs):
     session API. See "The cinderclient Python API" page at
     python-cinderclient's doc.
     """
-    # NOTE(jethro): options.profile demonstrate the --profile, here set to
-    # be true by default
-    options.profile = "123"
-    #profile = osprofiler_profiler and options.profile
-    profile = options.profile
-    if profile and is_sampled(SAMPLING_RATE):
-        print("sampled request")
-        osprofiler_profiler.init(options.profile)
-
     api_version, client_class = _get_client_class_and_version(version)
+
     return client_class(api_version=api_version,
                         *args, **kwargs)

--- a/cinderclient/shell.py
+++ b/cinderclient/shell.py
@@ -782,12 +782,6 @@ class OpenStackCinderShell(object):
 
         # NOTE(jethro): options.profile demonstrate the --profile, here set to
         # be true by default
-        options.profile = "123"
-        profile = osprofiler_profiler and options.profile
-        if profile and is_sampled(SAMPLING_RATE):
-            print("sampled request")
-            osprofiler_profiler.init(options.profile)
-
         try:
             args.func(self.cs, args)
         finally:
@@ -796,10 +790,10 @@ class OpenStackCinderShell(object):
                 print("Trace ID: %s" % trace_id)
                 #print("To display trace use next command:\n"
                 #      "osprofiler trace show --html %s " % trace_id)
-                print("Traces are dumped into /home/centos/traces")
+                print("Traces are dumped into /home/admin/traces")
                 cmd = "source /root/keystonerc_admin ; osprofiler trace show" + \
-                    " --dot " + trace_id + " --out " + "/home/centos/traces/" + \
-                    str(trace_id) + ".dot" + " --connection-string mongodb://192.168.0.70:27017"
+                    " --dot " + trace_id + " --out " + "/home/admin/traces/" + \
+                    str(trace_id) + ".dot" + " --connection-string mongodb://172.16.10.190:27017"
                 subprocess.call(["bash", "-c", cmd])
             except:
                 pass

--- a/cinderclient/shell.py
+++ b/cinderclient/shell.py
@@ -766,9 +766,13 @@ class OpenStackCinderShell(object):
                                endpoint_api_version)
 
         profile = osprofiler_profiler and options.profile
-        print("DEBUG: ...")
+        print("DEBUG: osprofiler_profiler...")
         print(osprofiler_profiler)
+        print("DEBUG:..options")
+        print(options.profile)
         print(options)
+        print("DEBUG: profile")
+        print(profile)
         if profile:
             osprofiler_profiler.init(options.profile)
 

--- a/cinderclient/shell.py
+++ b/cinderclient/shell.py
@@ -766,6 +766,9 @@ class OpenStackCinderShell(object):
                                endpoint_api_version)
 
         profile = osprofiler_profiler and options.profile
+        print("DEBUG: ...")
+        print(osprofiler_profiler)
+        print(options)
         if profile:
             osprofiler_profiler.init(options.profile)
 


### PR DESCRIPTION
This PR enable the end to end tracing in Cinder part. 

It achieves: 
i) tracing is enabled from a layer below the original way osprofiler works -- only from cmd. It now start from the class/function level, which means every usage of cinderclient class will have tracing enabled naturally (i.e. Rally, horizon, Giji, etc)
ii) tracing is done on a sampling based, i.e. sampling rate defined will be able to dynamically changed and can efficiently reduce the overhead of turning tracing infra always on.
iii) however, of some legacy reason, dumping traces is little tricky here. It write the trace-id to a specifically file and we have to dump all the traces there.